### PR TITLE
Validate loader branch syntax

### DIFF
--- a/src/main/java/cam72cam/universalmodcore/Setup.java
+++ b/src/main/java/cam72cam/universalmodcore/Setup.java
@@ -23,7 +23,18 @@ public class Setup {
                         Files.readAllBytes(Paths.get("umc.json"))
                 ))
         ).getAsJsonObject();
+
+        if (args.length == 0) {
+            System.err.println("No loader branch specified! Available branches can be found in the UniversalModCore GitHub repository.");
+            return;
+        }
         String loaderBranch = args[0];
+        String[] split = loaderBranch.split("-");
+        if (split.length < 2 || !split[0].matches("1\\.\\d*\\.\\d*") || !split[1].matches("[\\w-]+")) {
+            System.err.println("Invalid loader branch! It should be in the format '<minecraft-version>-<loader>'. For example, '1.12.2-forge'.");
+            return;
+        }
+
         Config config = new Config(configObj, loaderBranch);
 
         ZipInputStream zip = new ZipInputStream(config.openJarStream());


### PR DESCRIPTION
When running the jar for the first time, there are no hints as to why it fails if you don't provide any arguments. If you do provide an argument, there are no hints as to why it's invalid. This PR first checks that an argument is provided, and mentions what it should be. It then checks its syntax to make sure it's at least sane before trying to fetch the git branch.