### PR TITLE
[feat] Added library block to UMC setup

### DIFF
--- a/src/main/java/cam72cam/universalmodcore/Config.java
+++ b/src/main/java/cam72cam/universalmodcore/Config.java
@@ -50,7 +50,9 @@ public class Config {
             this.dependencies = data.get("dependencies").getAsJsonObject().entrySet().stream()
                     .map((e) -> new Dependency(e.getKey(), e.getValue().getAsJsonObject()))
                     .collect(Collectors.toList());
-            data.get("libraries").getAsJsonArray().forEach(e -> libraries.add(new Library(e.getAsJsonObject())));
+            if (data.has("libraries")) {
+                data.get("libraries").getAsJsonArray().forEach(e -> libraries.add(new Library(e.getAsJsonObject())));
+            }
         }
     }
 

--- a/src/main/java/cam72cam/universalmodcore/Config.java
+++ b/src/main/java/cam72cam/universalmodcore/Config.java
@@ -157,8 +157,8 @@ public class Config {
         }
 
         vars.put("LIB_REPOS", stripNewline(libRepos));
-        vars.put("SHADOW", stripNewline(depends));
-        vars.put("RELOCATE", stripNewline(relocate));
+        vars.put("MOD_DEPENDENCIES", stripNewline(depends));
+        vars.put("RELOCATION", stripNewline(relocate));
 
         String version = require("umc.version", umc.version);
 

--- a/src/main/java/cam72cam/universalmodcore/Config.java
+++ b/src/main/java/cam72cam/universalmodcore/Config.java
@@ -1,6 +1,5 @@
 package cam72cam.universalmodcore;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -12,8 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class Config {
     public final Mod mod;

--- a/src/main/java/cam72cam/universalmodcore/Config.java
+++ b/src/main/java/cam72cam/universalmodcore/Config.java
@@ -149,7 +149,7 @@ public class Config {
             }
 
             if (library.isDir) {
-                flatDirs.add(library.repo);
+                flatDirs.add("'" + library.repo + "'");
             } else {
                 repoLines.add("\tmaven { url = \"" + library.repo + "\"");
             }


### PR DESCRIPTION
This PR adds the possibility to add libraries for UMC submods directly in the `umc.json`. Highly inspired by https://github.com/TeamOpenIndustry/UniversalModCore/issues/204. Before this PR is mergeable, we need to enable the shade plugin in the build.gradle template, and add some aditional variable tags.

Usage:
```json
"mod": {
    //...
    "libraries": [
        {
            "repository": "maven repositor like eg: https://repo1.maven.org/maven2/",
            "artifact": "groovy short form like: com.google.code.gson:gson:2.13.2"
            "path": "path to a jar file, alternative to repository + artifact"
            "type": "shade/implementation/runtime/(compile)"
            "relocate": "old.path | new.path"
            "onlyIn": ["1.12.2-forge", "1.17.1-forge"]
        }
    ]
}
```